### PR TITLE
firebase認証の導入に伴う変更

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,51 @@
 
 
 [[projects]]
+  digest = "1:34be41e93f60476c104eb16212eeaac4f9cbf6a8a2ae0062de6491c4bdd1d1f9"
+  name = "cloud.google.com/go"
+  packages = [
+    "compute/metadata",
+    "firestore",
+    "firestore/apiv1beta1",
+    "iam",
+    "internal",
+    "internal/atomiccache",
+    "internal/btree",
+    "internal/fields",
+    "internal/optional",
+    "internal/trace",
+    "internal/version",
+    "storage",
+  ]
+  pruneopts = "UT"
+  revision = "64a2037ec6be8a4b0c1d1f706ed35b428b989239"
+  version = "v0.26.0"
+
+[[projects]]
+  digest = "1:dc27d9777febe9e63ab33a2cd15e31ce8d9463932d2472cc7097dc662dedb5ab"
+  name = "contrib.go.opencensus.io/exporter/stackdriver"
+  packages = ["propagation"]
+  pruneopts = "UT"
+  revision = "2b93072101d466aa4120b3c23c2e1b08af01541c"
+  version = "v0.6.0"
+
+[[projects]]
+  digest = "1:98aff2721f6c162b8f13fc9d8335d21904f7839b6b2b72e8bd180529b4b682c1"
+  name = "firebase.google.com/go"
+  packages = [
+    ".",
+    "auth",
+    "db",
+    "iid",
+    "internal",
+    "messaging",
+    "storage",
+  ]
+  pruneopts = "UT"
+  revision = "64bf7fbd5f65febae9264fa23b3dc213a9748c96"
+  version = "v3.3.0"
+
+[[projects]]
   digest = "1:adea5a94903eb4384abef30f3d878dc9ff6b6b5b0722da25b82e5169216dfb61"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
@@ -10,16 +55,215 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:c25289f43ac4a68d88b02245742347c94f1e108c534dda442188015ff80669b3"
+  digest = "1:72856926f8208767b837bf51e3373f49139f61889b67dc7fd3c2a0fd711e3f7a"
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/empty",
+    "ptypes/struct",
+    "ptypes/timestamp",
+    "ptypes/wrappers",
+  ]
+  pruneopts = "UT"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:e145e9710a10bc114a6d3e2738aadf8de146adaa031854ffdf7bbfe15da85e63"
+  name = "github.com/googleapis/gax-go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "317e0006254c44a0ac427cc52a0e083ff0b9622f"
+  version = "v2.0.0"
+
+[[projects]]
+  digest = "1:464a3be290af8d1254461cfbf8fdcd16c602fc28946b2bb5fad48d38dbc67e2c"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "internal",
+    "internal/tagencoding",
+    "plugin/ocgrpc",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/propagation",
+  ]
+  pruneopts = "UT"
+  revision = "7b558058b7cc960667590e5413ef55157b06652e"
+  version = "v0.15.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:1c14517b2f106c61d75006199b46a46576058661d469658cb0f90739919641d2"
+  name = "golang.org/x/net"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace",
+  ]
+  pruneopts = "UT"
+  revision = "4bcd98cce591d8c7061bf313d7a3cbad05b58549"
+
+[[projects]]
+  branch = "master"
+  digest = "1:f645667d687fc8bf228865a2c5455824ef05bad08841e673673ef2bb89ac5b90"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt",
+  ]
+  pruneopts = "UT"
+  revision = "d2e6202438beef2727060aa7cabdd924d92ebfd9"
+
+[[projects]]
+  branch = "master"
+  digest = "1:19f92ce03256cc8a4467054842ec81f081985becd92bbc443e7604dfe801e6a8"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  pruneopts = "UT"
+  revision = "4910a1d54f876d7b22162a85f4d066d3ee649450"
+
+[[projects]]
+  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
+  name = "golang.org/x/text"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = "UT"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:001ccde1fc1459cb3fc25475b30c6a54f68ae1574ac196a4440d04d372da0745"
+  name = "google.golang.org/api"
+  packages = [
+    "gensupport",
+    "googleapi",
+    "googleapi/internal/uritemplates",
+    "googleapi/transport",
+    "identitytoolkit/v3",
+    "internal",
+    "iterator",
+    "option",
+    "storage/v1",
+    "transport",
+    "transport/grpc",
+    "transport/http",
+  ]
+  pruneopts = "UT"
+  revision = "943e5aafc110feadee8cf71cde31afa0d1bab9f8"
+
+[[projects]]
+  digest = "1:0e781d9592d20f30c4280da30f27b448b4815215f9b43b5258b763a79fb98e98"
   name = "google.golang.org/appengine"
-  packages = ["cloudsql"]
+  packages = [
+    ".",
+    "cloudsql",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/socket",
+    "internal/urlfetch",
+    "socket",
+    "urlfetch",
+  ]
   pruneopts = "UT"
   revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
   version = "v1.1.0"
 
+[[projects]]
+  branch = "master"
+  digest = "1:aeadc616c96444425ef06579cd8769a242f640669c8b0169ebb32ef3dc8d921b"
+  name = "google.golang.org/genproto"
+  packages = [
+    "googleapis/api/annotations",
+    "googleapis/firestore/v1beta1",
+    "googleapis/iam/v1",
+    "googleapis/rpc/code",
+    "googleapis/rpc/status",
+    "googleapis/type/latlng",
+  ]
+  pruneopts = "UT"
+  revision = "c66870c02cf823ceb633bcd05be3c7cda29976f4"
+
+[[projects]]
+  digest = "1:f4fdb603068ae856b9eb05772787bf4966b1fabd3b074e3f840aab417bd992c3"
+  name = "google.golang.org/grpc"
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "credentials/oauth",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/transport",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+  ]
+  pruneopts = "UT"
+  revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
+  version = "v1.14.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = ["github.com/go-sql-driver/mysql"]
+  input-imports = [
+    "firebase.google.com/go",
+    "github.com/go-sql-driver/mysql",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,6 +26,10 @@
 
 
 [[constraint]]
+  name = "firebase.google.com/go"
+  version = "3.3.0"
+
+[[constraint]]
   name = "github.com/go-sql-driver/mysql"
   version = "1.4.0"
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ TOKYO_C_DATABASE_NAME="tokyoC_DB"
 
 and execute `./install-database .env`.
 
+## Place a Firebase Credentials
+
+`cat > firebase-credentials.json`
+
 ## Establish a Server
 
 Execute `DATABASE_TYPE=mysql DATABASE_URI="root:PASSWORD@tcp(127.0.0.1)/tokyoC_DB" ~/bin/tokyo-c-server -port 9000` and you have an endpoint at `http://localhost:9000/`.

--- a/data_types.go
+++ b/data_types.go
@@ -4,11 +4,6 @@ import (
 	"time"
 )
 
-type Person struct {
-	Id   int64
-	Name string
-}
-
 type Channel struct {
 	Id   int64
 	Name string

--- a/data_types.go
+++ b/data_types.go
@@ -17,7 +17,7 @@ type Channel struct {
 type Message struct {
 	Id       int64
 	Channel  int64
-	Author   int64
+	Author   string
 	IsEvent  int
 	PostedAt time.Time
 	Content  string

--- a/install-database
+++ b/install-database
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ -n "$1" ]; then
 	source "$1"
 fi
@@ -11,15 +13,15 @@ CREATE DATABASE ${TOKYO_C_DATABASE_NAME};
 USE ${TOKYO_C_DATABASE_NAME};
 
 CREATE TABLE friendships (
-	person_0 INT,
-	person_1 INT,
+	person_0 VARCHAR(256),
+	person_1 VARCHAR(256),
 	UNIQUE(person_0, person_1)
 );
 
 CREATE TABLE messages (
         id INT PRIMARY KEY AUTO_INCREMENT,
         channel INT,
-        author INT,
+        author VARCHAR(256),
         is_event BOOLEAN,
         posted_at DATETIME,
         content VARCHAR(4096),
@@ -32,15 +34,9 @@ CREATE TABLE channels (
 );
 
 CREATE TABLE participations (
-        person INT,
+        person VARCHAR(256),
         channel INT,
         UNIQUE(person, channel)
-);
-
-CREATE TABLE people (
-        id INT PRIMARY KEY AUTO_INCREMENT,
-        name VARCHAR(128),
-        token VARCHAR(1024)
 );
 EOS
 

--- a/main.go
+++ b/main.go
@@ -12,7 +12,12 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/context"
+	"firebase.google.com/go"
+	firebase_auth "firebase.google.com/go/auth"
 	_ "github.com/go-sql-driver/mysql"
+
+	"google.golang.org/api/option"
 )
 
 type http_status struct {
@@ -21,8 +26,9 @@ type http_status struct {
 }
 
 var db *sql.DB
+var idp *firebase_auth.Client
 
-func authenticate(request *http.Request, subject *int) error {
+func authenticate(request *http.Request, subject *string) error {
 	var (
 		auth_type string
 		token     string
@@ -34,7 +40,13 @@ func authenticate(request *http.Request, subject *int) error {
 		return errors.New("auth type must be Bearer")
 	}
 
-	*subject = 1
+	verified, err := idp.VerifyIDToken(context.Background(), token)
+
+	if err != nil {
+		return errors.New("invalid token: "+err.Error())
+	}
+
+	*subject = verified.UID
 
 	return nil
 }
@@ -45,10 +57,12 @@ func main() {
 
 		port    int
 		pidfile string
+		firebase_credentials string
 	)
 
 	flag.IntVar(&port, "port", 80, "specifies port number to be binded")
 	flag.StringVar(&pidfile, "pidfile", "/tmp/tokyo-c.pid", "specifies path to pidfile")
+	flag.StringVar(&firebase_credentials, "firebase", "firebase-credentials.json", "specifies path to firebase credentials")
 
 	flag.Parse()
 
@@ -56,6 +70,20 @@ func main() {
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "failed to connect database: "+err.Error())
+		return
+	}
+
+	firebase_app, err := firebase.NewApp(context.Background(), nil, option.WithCredentialsFile(firebase_credentials))
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "firebase initialization failed: "+err.Error())
+		return
+	}
+
+	idp, err = firebase_app.Auth(context.Background())
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "firebase authentication failed: "+err.Error())
 		return
 	}
 
@@ -80,11 +108,13 @@ func main() {
 	message_handler := NewMessageServer(stamp_message)
 
 	http.HandleFunc("/streams/", func(writer http.ResponseWriter, request *http.Request) {
-		var subject int
+		var subject string
 
-		if authenticate(request, &subject) != nil {
+		err := authenticate(request, &subject)
+		
+		if err != nil {
 			writer.WriteHeader(401)
-			fmt.Fprintln(writer, "auth failed")
+			fmt.Fprintln(writer, err.Error())
 			return
 		}
 
@@ -141,10 +171,12 @@ func stamp_message(channel_id int64, message *Message) error {
 }
 
 func endpoint_friendships(writer http.ResponseWriter, request *http.Request) *http_status {
-	var subject int
+	var subject string
 
-	if authenticate(request, &subject) != nil {
-		return &http_status{401, "auth failed"}
+	err := authenticate(request, &subject)
+	
+	if err!= nil {
+		return &http_status{401, err.Error()}
 	}
 
 	person_id, err := strconv.Atoi(strings.TrimPrefix(request.URL.Path, "/friendships/"))
@@ -199,10 +231,12 @@ func endpoint_friendships(writer http.ResponseWriter, request *http.Request) *ht
 }
 
 func endpoint_channels(writer http.ResponseWriter, request *http.Request) *http_status {
-	var subject int
+	var subject string
 
-	if authenticate(request, &subject) != nil {
-		return &http_status{401, "auth failed"}
+	err := authenticate(request, &subject)
+	
+	if err != nil {
+		return &http_status{401, err.Error()}
 	}
 
 	if err := request.ParseForm(); err != nil {
@@ -361,10 +395,12 @@ func endpoint_channels(writer http.ResponseWriter, request *http.Request) *http_
 }
 
 func endpoint_messages(writer http.ResponseWriter, request *http.Request) *http_status {
-	var subject int
+	var subject string
 
-	if authenticate(request, &subject) != nil {
-		return &http_status{401, "auth failed"}
+	err := authenticate(request, &subject)
+	
+	if err != nil {
+		return &http_status{401, err.Error()}
 	}
 
 	if request.Method != "GET" {

--- a/main.go
+++ b/main.go
@@ -200,18 +200,18 @@ func endpoint_friendships(writer http.ResponseWriter, request *http.Request) *ht
 		return &http_status{405, "method not allowed"}
 	}
 
-	rows, err := db.Query("SELECT id, name FROM friendships, people WHERE person_0 = ? AND person_1 = id", subject)
+	rows, err := db.Query("SELECT person_1 FROM friendships WHERE person_0 = ? AND person_1 = id", subject)
 
 	if err != nil {
 		return &http_status{500, err.Error()}
 	}
 
-	var person Person
+	friends := make([]string, 0, 16)
 
-	friends := make([]Person, 0, 16)
+	var person string
 
 	for rows.Next() {
-		if err := rows.Scan(&person.Id, &person.Name); err != nil {
+		if err := rows.Scan(&person); err != nil {
 			return &http_status{500, err.Error()}
 		}
 
@@ -358,24 +358,24 @@ func endpoint_channels(writer http.ResponseWriter, request *http.Request) *http_
 
 	var channel struct {
 		Name         string
-		Participants []Person
+		Participants []string
 	}
 
 	if err := row.Scan(&channel.Name); err != nil {
 		return &http_status{410, err.Error()}
 	}
 
-	rows, err := db.Query("SELECT id, name FROM participations, people WHERE channel = ? AND person = id", channel_id)
-	channel.Participants = make([]Person, 0, 16)
+	rows, err := db.Query("SELECT person FROM participations WHERE channel = ?", channel_id)
+	channel.Participants = make([]string, 0, 16)
 
 	if err != nil {
 		return &http_status{500, err.Error()}
 	}
 
-	var person Person
+	var person string
 
 	for rows.Next() {
-		if err := rows.Scan(&person.Id, &person.Name); err != nil {
+		if err := rows.Scan(&person); err != nil {
 			return &http_status{500, err.Error()}
 		}
 


### PR DESCRIPTION
当初はfirebaseのもつユーザー情報と紐付けてtokyo-c-serverのデータベースでも独自にユーザー情報([install-database](https://github.com/line-school2018summer/tokyo-c-server/blob/d5070b5797e338f7643f0307c5bebb4998fec4e1/install-database#L40)を見よ)をmaintainする予定であった。
しかし、それらの間でつねに整合性をとるのは困難なので、サーバーではトークンが正しいことの検証とトークンからUIDを取り出すことのみを行なうことにする。
サーバーはUIDによってのみユーザーを区別し、サーバーがユーザーについて知る情報はUIDのみである。
ユーザーの名前やアバターの解決はクライアントサイドで行うことを考えている。